### PR TITLE
VP-5640: Use ForwardHeaders to solve issue with https via proxy

### DIFF
--- a/webstore-app/overlays/qa/kustomization.yaml
+++ b/webstore-app/overlays/qa/kustomization.yaml
@@ -28,4 +28,4 @@ images:
   newTag: master-3.24.0-11620-6ed934a0
 - name: docker.pkg.github.com/virtocommerce/vc-storefront/storefront
   newName: docker.pkg.github.com/virtocommerce/vc-demo-storefront/demo-storefront
-  newTag: 1.4.0-alpha.915-dev-8498301e
+  newTag: 1.4.0-alpha.920-vp-5640-6dfacbaa

--- a/webstore-app/overlays/qa/storefront-cm.yaml
+++ b/webstore-app/overlays/qa/storefront-cm.yaml
@@ -4,9 +4,8 @@ metadata:
   name: storefront-cm
 data:
     APPINSIGHTS_INSTRUMENTATIONKEY: "4122074c-f2ad-489b-811f-d557350fb644"
+    ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
     CookieAuthenticationOptions__ExpireTimeSpan: "12:00:00"
     SnapshotCollectorConfiguration__IsEnabled: "false"
     Swagger__UI__Enable: "true"
     VirtoCommerce__Endpoint__Url: https://$(VC_PLATFORM_SERVICE).$(VC_NAMESPACE).govirto.com
-    VirtoCommerce__StoreUrls__B2B-store: https://$(VC_STOREFRONT_SERVICE).$(VC_NAMESPACE).govirto.com/B2B-store/
-    VirtoCommerce__StoreUrls__Electronics: https://$(VC_STOREFRONT_SERVICE).$(VC_NAMESPACE).govirto.com/


### PR DESCRIPTION
Login on behalf issue was caused by the workaround of https problem with the StoreUrls setting of Storefront.
New solution is right. 
Also we need overall smoke test. Not only login on behalf testing. 

https://devblogs.microsoft.com/aspnet/forwarded-headers-middleware-updates-in-net-core-3-0-preview-6/